### PR TITLE
Refactor Slotmaps: Introduce 'ref'

### DIFF
--- a/src/Slotmaps/SecondaryMap/SCSlot.cs
+++ b/src/Slotmaps/SecondaryMap/SCSlot.cs
@@ -2,17 +2,11 @@
 public partial class SecondaryMap<TKey, TValue>
 {
     [DebuggerDisplay("{ToString()}")]
-    internal struct Slot(TValue value, uint version)
+    private struct Slot(TValue value, uint version)
     {
-        private TValue _value = value;
+        public TValue Value = value;
 
-        public TValue Value
-        {
-            get => Occupied ? _value : throw new InvalidOperationException("Slot is empty");
-            private set => _value = value;
-        }
-
-        public uint Version { get; private set; } = version;
+        public uint Version = version;
 
         public readonly bool Occupied => Version != 0;
 

--- a/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
+++ b/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
@@ -191,7 +191,8 @@ public partial class SecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey,
     /// <param name="key">The key to insert or update the value for.</param>
     /// <param name="value">The value to insert or update.</param>
     /// <returns>
-    ///   The updated key after the insertion or update with an incremented version number.
+    ///   The previous value associated with the specified key if applicable, or the new
+    ///   value itself if the slot doesn't contain anything.
     /// </returns>
     /// <exception cref="KeyNotFoundException">
     ///   Thrown if the specified <paramref name="key"/> is not found in the secondary map.

--- a/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
+++ b/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
@@ -212,8 +212,8 @@ public partial class SecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey,
     /// <param name="key">The key to insert or update the value for.</param>
     /// <param name="value">The value to insert or update.</param>
     /// <returns>
-    ///   The previous value associated with the specified key if applicable, or the new
-    ///   value itself if the slot doesn't contain anything.
+    ///   The previous value associated with the specified slot key if it existed; otherwise,
+    ///   the provided <paramref name="value"/>.
     /// </returns>
     /// <exception cref="KeyNotFoundException">
     ///   Thrown if the specified <paramref name="key"/> is not found in the secondary map.

--- a/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
+++ b/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
@@ -1,4 +1,4 @@
-﻿namespace FlashyDJ.Slotmaps;
+namespace FlashyDJ.Slotmaps;
 
 /// <summary>
 ///   Represents a secondary slot map that associates keys of type <typeparamref name="TKey"/> for efficiently
@@ -88,7 +88,7 @@ public partial class SecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey,
     /// </returns>
     /// <seealso cref="TryGet"/>
     public bool ContainsKey(TKey key) =>
-        !key.IsNull && key.Index < _slots.Length
+        !key.IsNull && key.Index <= _slots.Length - 1
         && _slots[key.Index].Version == key.Version;
 
     /// <summary>

--- a/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
+++ b/src/Slotmaps/SecondaryMap/SecondaryMap`2.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
 namespace FlashyDJ.Slotmaps;
 
 /// <summary>
@@ -66,17 +69,16 @@ public partial class SecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey,
     public SlotValueCollection Values => _values ??= new SlotValueCollection(this);
 
     /// <summary>
-    ///   Gets or sets the value associated with the specified key.
+    ///   Gets the value associated with the specified key.
     /// </summary>
     /// <param name="key">The key to retrieve or set the value for.</param>
     /// <value>The value associated with the specified key.</value>
     /// <exception cref="KeyNotFoundException">
     ///   Thrown if the specified <paramref name="key"/> is not found in the secondary map.
     /// </exception>
-    public TValue this[TKey key]
+    public ref TValue this[TKey key]
     {
-        get => Get(key);
-        set => Insert(key, value);
+        get => ref Get(key);
     }
 
     /// <summary>
@@ -178,9 +180,28 @@ public partial class SecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey,
     ///   Thrown if the specified <paramref name="key"/> is not found in the secondary map.
     /// </exception>
     /// <seealso cref="TryGet"/>
-    public TValue Get(TKey key) =>
-        ContainsKey(key) ? _slots[key.Index].Value
-                         : throw ThrowHelper.GetKeyNotFoundException_MaybeNull(key);
+    public ref TValue Get(TKey key)
+    {
+        if (!ContainsKey(key))
+            ThrowHelper.ThrowKeyNotFoundException_MaybeNull(key);
+
+        return ref _slots[key.Index].Value;
+    }
+
+    /// <summary>
+    ///   Gets a reference to the value associated with the specified key in the secondary map.
+    ///   If the key is not found, returns a null reference of type <typeparamref name="TValue"/>.
+    /// </summary>
+    /// <param name="key">The key to retrieve the value for.</param>
+    /// <returns>A reference to the value associated with the specified key or a null reference.</returns>
+    /// <remarks>
+    ///   The returned reference may be null, and its nullness can be detected using
+    ///   <see cref="Unsafe.IsNullRef{T}(ref readonly T)"/>.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public ref TValue GetRefOrNullRef(TKey key) =>
+        ref ContainsKey(key) ? ref _slots[key.Index].Value
+                             : ref Unsafe.NullRef<TValue>();
 
     /// <inheritdoc/>
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => new Enumerator(this);

--- a/src/Slotmaps/SlotMap/SMSlot.cs
+++ b/src/Slotmaps/SlotMap/SMSlot.cs
@@ -2,19 +2,13 @@
 public partial class SlotMap<TKey, TValue>
 {
     [DebuggerDisplay("{ToString()}")]
-    internal struct Slot(TValue value, uint version)
+    private struct Slot(TValue value, uint version)
     {
-        private TValue _value = value;
+        public TValue Value = value;
 
-        public TValue Value
-        {
-            get => Occupied ? _value : throw new InvalidOperationException("Slot is empty");
-            set => _value = value;
-        }
+        public uint Version = version;
 
-        public uint Version { get; private set; } = version;
-
-        public int NextFree { get; private set; }
+        public int NextFree;
 
         public readonly bool Occupied => Version % 2 > 0;
 

--- a/src/Slotmaps/SlotMap/SlotMap`2.cs
+++ b/src/Slotmaps/SlotMap/SlotMap`2.cs
@@ -1,4 +1,4 @@
-﻿namespace FlashyDJ.Slotmaps;
+namespace FlashyDJ.Slotmaps;
 
 /// <summary>
 ///   Represents a slot map data structure that associates keys of type <typeparamref name="TKey"/>
@@ -86,7 +86,7 @@ public partial class SlotMap<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TVal
     /// </returns>
     /// <seealso cref="TryGet"/>
     public bool ContainsKey(TKey key) =>
-        !key.IsNull && key.Index < _slots.Length
+        !key.IsNull && key.Index <= _slots.Length - 1
         && _slots[key.Index].Version == key.Version;
 
     /// <summary>

--- a/src/Slotmaps/SparseSecondaryMap/SSSlot.cs
+++ b/src/Slotmaps/SparseSecondaryMap/SSSlot.cs
@@ -3,11 +3,11 @@
 public partial class SparseSecondaryMap<TKey, TValue>
 {
     [DebuggerDisplay("{ToString()}")]
-    internal struct Slot(TValue value, uint version)
+    private struct Slot(TValue value, uint version)
     {
-        public TValue Value { get; private set; } = value;
+        public TValue Value = value;
 
-        public uint Version { get; private set; } = version;
+        public uint Version = version;
 
         public TValue Update(TValue value, uint version)
         {

--- a/src/Slotmaps/SparseSecondaryMap/SparseSecondaryMap`2.cs
+++ b/src/Slotmaps/SparseSecondaryMap/SparseSecondaryMap`2.cs
@@ -71,10 +71,10 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     public SlotValueCollection Values => _values ??= new SlotValueCollection(this);
 
     /// <summary>
-    ///   Gets or sets the value associated with the specified <see cref="SlotKey"/>.
+    ///   Gets or sets the value associated with the specified slot key.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> whose associated value is to be retrieved or set.
+    ///   The slot key whose associated value is to be retrieved or set.
     /// </param>
     /// <value>
     ///   The value associated with the specified <paramref name="key"/>.
@@ -89,13 +89,13 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     }
 
     /// <summary>
-    ///   Determines whether the secondary map contains the specified <see cref="SlotKey"/>.
+    ///   Determines whether the secondary map contains the specified slot key.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> to locate in the sparse secondary map.
+    ///   The slot key to locate in the sparse secondary map.
     /// </param>
     /// <returns>
-    ///   <see langword="true"/> if the sparse secondary map contains an entry with the specified <see cref="SlotKey"/> that matches both the index and version;
+    ///   <see langword="true"/> if the sparse secondary map contains an entry with the specified slot key that matches both the index and version;
     ///   otherwise, <see langword="false"/>.
     /// </returns>
     public bool ContainsKey(TKey key)
@@ -163,13 +163,13 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     public int EnsureCapacity(int capacity) => _slots.EnsureCapacity(capacity);
 
     /// <summary>
-    ///   Gets the value associated with the specified <see cref="SlotKey"/>.
+    ///   Gets the value associated with the specified slot key.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> to look up in the sparse secondary map.
+    ///   The slot key to look up in the sparse secondary map.
     /// </param>
     /// <returns>
-    ///   The value associated with the specified <see cref="SlotKey"/>.
+    ///   The value associated with the specified slot key.
     /// </returns>
     /// <exception cref="KeyNotFoundException">
     ///   Thrown if the specified <paramref name="key"/> is not found in the slot map.
@@ -201,21 +201,21 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => new Enumerator(this);
 
     /// <summary>
-    ///   Inserts a value into the sparse secondary map associated with the specified <see cref="SlotKey"/>.
+    ///   Inserts a value into the sparse secondary map associated with the specified slot key.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> with which to associate the value.
+    ///   The slot key with which to associate the value.
     /// </param>
     /// <param name="value">
     ///   The value to insert into the sparse secondary map.
     /// </param>
     /// <returns>
-    ///   The previous value associated with the specified <see cref="SlotKey"/> if it existed; otherwise,
+    ///   The previous value associated with the specified slot key if it existed; otherwise,
     ///   the provided <paramref name="value"/>.
     /// </returns>
     /// <exception cref="KeyNotFoundException">
     ///   Thrown if the specified <paramref name="key"/> is not found or if the
-    ///   provided <see cref="SlotKey"/> is an older version than an existing entry.
+    ///   provided slot key is an older version than an existing entry.
     /// </exception>
     public TValue Insert(TKey key, TValue value)
     {
@@ -233,16 +233,16 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     }
 
     /// <summary>
-    ///   Removes the value with the specified <see cref="SlotKey"/> from the sparse secondary map.
+    ///   Removes the value with the specified slot key from the sparse secondary map.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> of the entry to remove.
+    ///   The slot key of the entry to remove.
     /// </param>
     /// <returns>
-    ///   The value associated with the removed <see cref="SlotKey"/> if the entry is found and removed successfully.
+    ///   The value associated with the removed slot key if the entry is found and removed successfully.
     /// </returns>
     /// <exception cref="KeyNotFoundException">
-    ///   Thrown if the provided <see cref="SlotKey"/> is invalid, has a version less than 1,
+    ///   Thrown if the provided slot key is invalid, has a version less than 1,
     ///   or does not exist in the sparse secondary map.
     /// </exception>
     public TValue Remove(TKey key) =>
@@ -253,7 +253,7 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     ///   Retains entries in the sparse secondary map based on a specified condition defined by a predicate function.
     /// </summary>
     /// <param name="predicate">
-    ///   A delegate that defines the condition for retaining elements. The delegate is called for each entry with its <see cref="SlotKey"/> and associated value as arguments.
+    ///   A delegate that defines the condition for retaining elements. The delegate is called for each entry with its slot key and associated value as arguments.
     /// </param>
     public void Retain(Func<TKey, TValue, bool> predicate)
     {
@@ -273,13 +273,13 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     }
 
     /// <summary>
-    ///   Tries to get the value associated with the specified <see cref="SlotKey"/> from the sparse secondary map.
+    ///   Tries to get the value associated with the specified slot key from the sparse secondary map.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> to locate in the <see cref="SparseSecondaryMap{TKey, TValue}"/>.
+    ///   The slot key to locate in the <see cref="SparseSecondaryMap{TKey, TValue}"/>.
     /// </param>
     /// <param name="value">
-    ///   When this method returns, contains the value associated with the specified <see cref="SlotKey"/>, if found; otherwise, the default value for <typeparamref name="TValue"/>.
+    ///   When this method returns, contains the value associated with the specified slot key, if found; otherwise, the default value for <typeparamref name="TValue"/>.
     /// </param>
     /// <returns>
     ///   <see langword="true"/> if the <paramref name="key"/> is found in the <see cref="SparseSecondaryMap{TKey, TValue}"/>; otherwise, <see langword="false"/>.
@@ -297,16 +297,16 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     }
 
     /// <summary>
-    ///   Tries to insert a value associated with the specified <see cref="SlotKey"/> into the sparse secondary map.
+    ///   Tries to insert a value associated with the specified slot key into the sparse secondary map.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> to associate with the value.
+    ///   The slot key to associate with the value.
     /// </param>
     /// <param name="value">
     ///   The value to insert into the sparse secondary map.
     /// </param>
     /// <param name="previousValue">
-    ///   When this method returns, contains the previous value associated with the specified <see cref="SlotKey"/>, if it exists;
+    ///   When this method returns, contains the previous value associated with the specified slot key, if it exists;
     ///   otherwise, the default value for <typeparamref name="TValue"/>.
     /// </param>
     /// <returns>
@@ -330,16 +330,16 @@ public partial class SparseSecondaryMap<TKey, TValue> : IEnumerable<KeyValuePair
     }
 
     /// <summary>
-    ///   Attempts to remove the entry with the specified <see cref="SlotKey"/> from the sparse secondary map.
+    ///   Attempts to remove the entry with the specified slot key from the sparse secondary map.
     /// </summary>
     /// <param name="key">
-    ///   The <see cref="SlotKey"/> of the entry to remove.
+    ///   The slot key of the entry to remove.
     /// </param>
     /// <param name="value">
     ///   When this method returns, contains the value associated with the specified <paramref name="key"/>, if found; otherwise, the default value for <typeparamref name="TValue"/>.
     /// </param>
     /// <returns>
-    ///   <see langword="true"/> if an entry with the specified <see cref="SlotKey"/> was found and removed successfully;
+    ///   <see langword="true"/> if an entry with the specified slot key was found and removed successfully;
     ///   otherwise, <see langword="false"/>.
     /// </returns>
     public bool TryRemove(TKey key, [MaybeNullWhen(false)] out TValue value)

--- a/tests/Slotmaps.Tests/SecondaryMap/Indexer.cs
+++ b/tests/Slotmaps.Tests/SecondaryMap/Indexer.cs
@@ -62,17 +62,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetInt_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<int>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = 10;
-
-        Assert.Equal(10, secondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                         int?                                         //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -109,17 +98,6 @@ public class Indexer
         secondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetIntNullable_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<int?>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = null;
-
-        Assert.Null(secondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -160,17 +138,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetString_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<string>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = "Value 1";
-
-        Assert.Equal("Value 1", secondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                       string?                                        //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -207,17 +174,6 @@ public class Indexer
         secondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetStringNullable_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<string?>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = null;
-
-        Assert.Null(secondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -258,17 +214,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetFloat_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<float>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = 1.1F;
-
-        Assert.Equal(1.1F, secondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                        float?                                        //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -305,17 +250,6 @@ public class Indexer
         secondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetFloatNullable_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<float?>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = null;
-
-        Assert.Null(secondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -356,17 +290,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetDateTime_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<DateTime>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = DateTime.Parse("2023-01-01");
-
-        Assert.Equal(DateTime.Parse("2023-01-01"), secondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                      DateTime?                                       //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -403,17 +326,6 @@ public class Indexer
         secondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetDateTimeNullable_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<DateTime?>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = null;
-
-        Assert.Null(secondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -454,17 +366,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetGuid_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<Guid>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE");
-
-        Assert.Equal(Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE"), secondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                        Guid?                                         //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -501,17 +402,6 @@ public class Indexer
         secondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => secondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetGuidNullable_InsertsValue()
-    {
-        var secondaryMap = new SecondaryMap<Guid?>();
-        var key = new SlotKey(1, 1);
-
-        secondaryMap[key] = null;
-
-        Assert.Null(secondaryMap[key]);
     }
 
 }

--- a/tests/Slotmaps.Tests/SlotMap/Indexer.cs
+++ b/tests/Slotmaps.Tests/SlotMap/Indexer.cs
@@ -68,15 +68,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetInt_UpdateValue_ReturnsUpdatedValue()
+    public void GetInt_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<int>();
         var key = slotMap.Insert(10);
 
         slotMap[key] = 20;
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(20, value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -123,15 +121,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetIntNullable_UpdateValue_ReturnsUpdatedValue()
+    public void GetIntNullable_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<int?>();
         var key = slotMap.Insert(null);
 
         slotMap[key] = 10;
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(10, value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -178,15 +174,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetString_UpdateValue_ReturnsUpdatedValue()
+    public void GetString_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<string>();
         var key = slotMap.Insert("Value 1");
 
         slotMap[key] = "Value 2";
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal("Value 2", value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -233,15 +227,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetStringNullable_UpdateValue_ReturnsUpdatedValue()
+    public void GetStringNullable_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<string?>();
         var key = slotMap.Insert(null);
 
         slotMap[key] = "Value 1";
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal("Value 1", value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -288,15 +280,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetFloat_UpdateValue_ReturnsUpdatedValue()
+    public void GetFloat_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<float>();
         var key = slotMap.Insert(1.1F);
 
         slotMap[key] = 2.2F;
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(2.2F, value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -343,15 +333,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetFloatNullable_UpdateValue_ReturnsUpdatedValue()
+    public void GetFloatNullable_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<float?>();
         var key = slotMap.Insert(null);
 
         slotMap[key] = 1.1F;
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(1.1F, value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -398,15 +386,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetDateTime_UpdateValue_ReturnsUpdatedValue()
+    public void GetDateTime_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<DateTime>();
         var key = slotMap.Insert(DateTime.Parse("2023-01-01"));
 
         slotMap[key] = DateTime.Parse("2023-02-01");
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(DateTime.Parse("2023-02-01"), value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -453,15 +439,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetDateTimeNullable_UpdateValue_ReturnsUpdatedValue()
+    public void GetDateTimeNullable_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<DateTime?>();
         var key = slotMap.Insert(null);
 
         slotMap[key] = DateTime.Parse("2023-01-01");
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(DateTime.Parse("2023-01-01"), value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -508,15 +492,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetGuid_UpdateValue_ReturnsUpdatedValue()
+    public void GetGuid_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<Guid>();
         var key = slotMap.Insert(Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE"));
 
         slotMap[key] = Guid.Parse("B9EAA78E-3CE3-4F19-85BF-C9F8F8D6C407");
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(Guid.Parse("B9EAA78E-3CE3-4F19-85BF-C9F8F8D6C407"), value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -563,15 +545,13 @@ public class Indexer
     }
 
     [Fact]
-    public void SetAndGetGuidNullable_UpdateValue_ReturnsUpdatedValue()
+    public void GetGuidNullable_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var slotMap = new SlotMap<Guid?>();
         var key = slotMap.Insert(null);
 
         slotMap[key] = Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE");
-        var value = slotMap[key with { Version = 3 }];
-
-        Assert.Equal(Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE"), value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
 }

--- a/tests/Slotmaps.Tests/SlotMapTests.cs
+++ b/tests/Slotmaps.Tests/SlotMapTests.cs
@@ -451,15 +451,13 @@ public class SlotMapTests
         }
 
         [Fact]
-        public void SetAndGet_UpdateValue_ReturnsUpdatedValue()
+        public void Get_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
         {
             var slotMap = new SlotMap<int>();
             var key = slotMap.Insert(42);
 
             slotMap[key] = 24;
-            var value = slotMap[key with { Version = 3 }];
-
-            Assert.Equal(24, value);
+            Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
         }
     }
 

--- a/tests/Slotmaps.Tests/SparseSecondaryMap/Indexer.cs
+++ b/tests/Slotmaps.Tests/SparseSecondaryMap/Indexer.cs
@@ -62,17 +62,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetInt_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<int>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = 10;
-
-        Assert.Equal(10, sparseSecondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                         int?                                         //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -109,17 +98,6 @@ public class Indexer
         sparseSecondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetIntNullable_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<int?>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = null;
-
-        Assert.Null(sparseSecondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -160,17 +138,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetString_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<string>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = "Value 1";
-
-        Assert.Equal("Value 1", sparseSecondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                       string?                                        //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -207,17 +174,6 @@ public class Indexer
         sparseSecondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetStringNullable_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<string?>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = null;
-
-        Assert.Null(sparseSecondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -258,17 +214,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetFloat_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<float>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = 1.1F;
-
-        Assert.Equal(1.1F, sparseSecondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                        float?                                        //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -305,17 +250,6 @@ public class Indexer
         sparseSecondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetFloatNullable_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<float?>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = null;
-
-        Assert.Null(sparseSecondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -356,17 +290,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetDateTime_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<DateTime>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = DateTime.Parse("2023-01-01");
-
-        Assert.Equal(DateTime.Parse("2023-01-01"), sparseSecondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                      DateTime?                                       //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -403,17 +326,6 @@ public class Indexer
         sparseSecondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetDateTimeNullable_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<DateTime?>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = null;
-
-        Assert.Null(sparseSecondaryMap[key]);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -454,17 +366,6 @@ public class Indexer
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
     }
 
-    [Fact]
-    public void SetGuid_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<Guid>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE");
-
-        Assert.Equal(Guid.Parse("A7CDEB8A-62A7-4AC6-90F6-8344309736DE"), sparseSecondaryMap[key]);
-    }
-
     //////////////////////////////////////////////////////////////////////////////////////////
     //                                        Guid?                                         //
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -501,17 +402,6 @@ public class Indexer
         sparseSecondaryMap.Insert(key1, null);
         
         Assert.Throws<KeyNotFoundException>(() => sparseSecondaryMap[key2]);
-    }
-
-    [Fact]
-    public void SetGuidNullable_InsertsValue()
-    {
-        var sparseSecondaryMap = new SparseSecondaryMap<Guid?>();
-        var key = new SlotKey(1, 1);
-
-        sparseSecondaryMap[key] = null;
-
-        Assert.Null(sparseSecondaryMap[key]);
     }
 
 }

--- a/tests/Slotmaps.Tests/Templates/Primary/PrimaryIndexerTestTemplate.t4
+++ b/tests/Slotmaps.Tests/Templates/Primary/PrimaryIndexerTestTemplate.t4
@@ -77,15 +77,13 @@ foreach (var data in dataTypes)
     }
 
     [Fact]
-    public void SetAndGet<#= typeTitle #>_UpdateValue_ReturnsUpdatedValue()
+    public void Get<#= typeTitle #>_UpdateValueWithNewerKey_ThrowsKeyNotFoundException()
     {
         var <#= varName #> = new <#= slotMapType #><<#= data.Key #>>();
         var key = <#= varName #>.Insert(<#= data.Value[0] #>);
 
         <#= varName #>[key] = <#= data.Value[1] #>;
-        var value = <#= varName #>[key with { Version = 3 }];
-
-        Assert.Equal(<#= data.Value[1] #>, value);
+        Assert.Throws<KeyNotFoundException>(() => slotMap[key with { Version = 3 }]);
     }
 
 <#

--- a/tests/Slotmaps.Tests/Templates/Secondary/SecondaryIndexerTestTemplate.t4
+++ b/tests/Slotmaps.Tests/Templates/Secondary/SecondaryIndexerTestTemplate.t4
@@ -71,17 +71,6 @@ foreach (var data in dataTypes)
         Assert.Throws<KeyNotFoundException>(() => <#= varName #>[key2]);
     }
 
-    [Fact]
-    public void Set<#= typeTitle #>_InsertsValue()
-    {
-        var <#= varName #> = new <#= slotMapType #><<#= data.Key #>>();
-        var key = new SlotKey(1, 1);
-
-        <#= varName #>[key] = <#= data.Value[0] #>;
-
-        <#= data.Key.EndsWith("?") ? "Assert.Null(" : $"Assert.Equal({data.Value[0]}, " #><#= varName #>[key]);
-    }
-
 <#
 }
 #>


### PR DESCRIPTION
This pull request make the following enhancements to SlotMap, SecondaryMap, SparseSecondaryMap classes:

1. Changed the *Indexer* and *Get* method to return value by reference.
2. Remove set in *Indexer*.
2. Introduced a new method *GetRefOrNullRef*.
3. Refactored the internal *Slots*
    * Modified access modifier of the slot from internal to private
    * Converted properties of *Slot* to fields
4. Remove invalid tests.
5. Improve documentation.